### PR TITLE
Add author name to comments

### DIFF
--- a/src/components/highlight/CommentList.ts
+++ b/src/components/highlight/CommentList.ts
@@ -121,11 +121,24 @@ export class CommentList extends Component {
                 cls: "hi-note-time"
             });
 
-            // 添加双击编辑提示
-            footer.createEl("span", {
-                text: "Double click to edit",
+            // 添加双击编辑提示（如果有作者信息则默认显示作者）
+            const editHint = footer.createEl("span", {
+                text: comment.author || "Double click to edit",
                 cls: "hi-note-edit-hint"
             });
+
+            // 如果有作者信息，在hover时切换文本
+            if (comment.author) {
+                editHint.style.display = "inline-block";
+
+                contentEl.addEventListener("mouseenter", () => {
+                    editHint.textContent = "Double click to edit";
+                });
+
+                contentEl.addEventListener("mouseleave", () => {
+                    editHint.textContent = comment.author!;
+                });
+            }
 
             // 操作按钮容器
             footer.createEl("div", {

--- a/src/components/highlight/CommentList.ts
+++ b/src/components/highlight/CommentList.ts
@@ -121,14 +121,19 @@ export class CommentList extends Component {
                 cls: "hi-note-time"
             });
 
-            // 添加双击编辑提示（如果有作者信息则默认显示作者）
+            // 获取插件设置
+            const plugin = (window as any).app?.plugins?.plugins?.['hi-note'];
+            const displayAuthor = plugin?.settings?.displayAuthorInfo ?? false;
+
+            // 添加双击编辑提示（如果有作者信息且设置启用则默认显示作者）
+            const shouldShowAuthor = displayAuthor && comment.author;
             const editHint = footer.createEl("span", {
-                text: comment.author || "Double click to edit",
+                text: shouldShowAuthor ? comment.author : "Double click to edit",
                 cls: "hi-note-edit-hint"
             });
 
-            // 如果有作者信息，在hover时切换文本
-            if (comment.author) {
+            // 如果有作者信息且设置启用，在hover时切换文本
+            if (shouldShowAuthor) {
                 editHint.style.display = "inline-block";
 
                 contentEl.addEventListener("mouseenter", () => {

--- a/src/components/highlight/HighlightCard.ts
+++ b/src/components/highlight/HighlightCard.ts
@@ -32,11 +32,18 @@ export class HighlightCard {
                 instance.destroy();
             }
         });
-        
+
         // 清空实例集合
         HighlightCard.cardInstances.clear();
     }
-    
+
+    // 静态方法：刷新所有卡片的评论列表
+    public static refreshAllComments(): void {
+        HighlightCard.cardInstances.forEach(instance => {
+            instance.updateComments(instance.highlight);
+        });
+    }
+
     // 静态方法：根据高亮ID查找HighlightCard实例
     public static findCardInstanceByHighlightId(highlightId: string): HighlightCard | null {
         for (const instance of HighlightCard.cardInstances) {

--- a/src/services/comment/CommentService.ts
+++ b/src/services/comment/CommentService.ts
@@ -87,8 +87,8 @@ export class CommentService {
         // 确保高亮有 ID
         if (!highlight.id) {
             highlight.id = IdGenerator.generateHighlightId(
-                this.currentFile?.path || '', 
-                highlight.position || 0, 
+                this.currentFile?.path || '',
+                highlight.position || 0,
                 highlight.text
             );
         }
@@ -101,7 +101,8 @@ export class CommentService {
             id: IdGenerator.generateCommentId(),
             content,
             createdAt: Date.now(),
-            updatedAt: Date.now()
+            updatedAt: Date.now(),
+            author: this.plugin.settings.authorName || undefined
         };
 
         highlight.comments.push(newComment);

--- a/src/settings/GeneralSettingsTab.ts
+++ b/src/settings/GeneralSettingsTab.ts
@@ -136,6 +136,18 @@ export class GeneralSettingsTab {
                     }
                 }));
 
+        // 作者信息设置
+        new Setting(container)
+            .setName(t('Author name'))
+            .setDesc(t('Optional identifier associated with any comments you create'))
+            .addText(text => text
+                .setPlaceholder('Your name')
+                .setValue(this.plugin.settings.authorName || '')
+                .onChange(async (value) => {
+                    this.plugin.settings.authorName = value;
+                    await this.plugin.saveSettings();
+                }));
+
         // 高亮提取设置组
         new Setting(container)
             .setName(t('Custom text extraction'))

--- a/src/settings/GeneralSettingsTab.ts
+++ b/src/settings/GeneralSettingsTab.ts
@@ -2,6 +2,7 @@ import { Setting, Notice, Modal } from 'obsidian';
 import { t } from '../i18n';
 import { DEFAULT_SETTINGS } from '../types';
 import { RegexRuleEditor } from './RegexRuleEditor';
+import { HighlightCard } from '../components/highlight/HighlightCard';
 
 export class GeneralSettingsTab {
     private plugin: any;
@@ -156,6 +157,8 @@ export class GeneralSettingsTab {
                 .onChange(async (value) => {
                     this.plugin.settings.displayAuthorInfo = value;
                     await this.plugin.saveSettings();
+                    // Refresh all comment UIs to reflect the new setting
+                    HighlightCard.refreshAllComments();
                 }));
 
         // 高亮提取设置组

--- a/src/settings/GeneralSettingsTab.ts
+++ b/src/settings/GeneralSettingsTab.ts
@@ -148,6 +148,16 @@ export class GeneralSettingsTab {
                     await this.plugin.saveSettings();
                 }));
 
+        new Setting(container)
+            .setName(t('Display author information'))
+            .setDesc(t('Show author name in comment footer when available'))
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.displayAuthorInfo ?? false)
+                .onChange(async (value) => {
+                    this.plugin.settings.displayAuthorInfo = value;
+                    await this.plugin.saveSettings();
+                }));
+
         // 高亮提取设置组
         new Setting(container)
             .setName(t('Custom text extraction'))

--- a/src/storage/HiNoteDataManager.ts
+++ b/src/storage/HiNoteDataManager.ts
@@ -33,6 +33,7 @@ export interface OptimizedComment {
     content: string;
     created: number;
     updated: number;
+    author?: string;
 }
 
 export interface FileMappingData {
@@ -308,7 +309,8 @@ export class HiNoteDataManager {
                 id: comment.id,
                 content: comment.content,
                 createdAt: comment.created,
-                updatedAt: comment.updated
+                updatedAt: comment.updated,
+                author: comment.author
             })) || []
         };
     }
@@ -351,7 +353,8 @@ export class HiNoteDataManager {
                 id: comment.id,
                 content: comment.content,
                 created: comment.createdAt,
-                updated: comment.updatedAt
+                updated: comment.updatedAt,
+                author: comment.author
             }));
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface PluginSettings extends HighlightSettings {
     };
     showCommentWidget?: boolean;
     authorName?: string;
+    displayAuthorInfo?: boolean;
 }
 
 // FileComment 接口已移除
@@ -240,7 +241,8 @@ export const DEFAULT_SETTINGS: PluginSettings = {
         surroundingLines: 3
     },
     showCommentWidget: true,
-    authorName: ''
+    authorName: '',
+    displayAuthorInfo: false
 };
 
 // 添加自定义事件类型

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface CommentItem {
     content: string;
     createdAt: number;
     updatedAt: number;
+    author?: string;
 }
 
 export interface HighlightInfo {
@@ -149,6 +150,7 @@ export interface PluginSettings extends HighlightSettings {
         maxLength?: number;
     };
     showCommentWidget?: boolean;
+    authorName?: string;
 }
 
 // FileComment 接口已移除
@@ -237,7 +239,8 @@ export const DEFAULT_SETTINGS: PluginSettings = {
         maxLength: 2000,
         surroundingLines: 3
     },
-    showCommentWidget: true
+    showCommentWidget: true,
+    authorName: ''
 };
 
 // 添加自定义事件类型

--- a/styles.css
+++ b/styles.css
@@ -561,15 +561,6 @@ settings:
     border-radius: 4px;
 }
 
-.hi-note-edit-hint {
-    display: none;
-    font-size: 11px;
-    color: var(--text-faint);
-    margin-left: 4px;
-    margin-top: 4px;
-    opacity: 0.7;
-}
-
 /* 当鼠标悬停在内容区域时显示编辑提示 */
 .hi-note:has(.hi-note-content:hover) .hi-note-edit-hint {
     display: inline-block;
@@ -591,6 +582,15 @@ settings:
     color: var(--text-faint);
     margin-right: auto;
     margin-top: 4px;
+}
+
+.hi-note-edit-hint {
+    display: none;
+    font-size: 11px;
+    color: var(--text-faint);
+    margin-left: 4px;
+    margin-top: 4px;
+    opacity: 0.7;
 }
 
 .hi-note-actions {


### PR DESCRIPTION
I'm using your plugin to work on documents collaboratively and thought it might be useful to associate author information with a comment. This PR adds settings for specifying an author identity when creating comments, showing or hiding author information, and updates the comment UI and persistence to include author information.

<img width="598" height="228" alt="Screenshot 2026-01-06 at 12 26 41 PM" src="https://github.com/user-attachments/assets/bc1cc6f7-1fa0-49e7-9de1-228d2101bf59" />

<img width="564" height="425" alt="Screenshot 2026-01-06 at 12 27 59 PM" src="https://github.com/user-attachments/assets/28396518-a5d3-4107-aae2-a37dba21e6f2" />

Thank you for all your work on HiNote! 🙏 
