### PR TITLE
Fix HiNote data migration on file rename

### DIFF
--- a/scripts/test-hinote-rename-fix.mjs
+++ b/scripts/test-hinote-rename-fix.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+
+const bootstrap = readFileSync("src/plugin/PluginBootstrap.ts", "utf8");
+const dataManager = readFileSync("src/storage/HiNoteDataManager.ts", "utf8");
+
+assert.match(
+  bootstrap,
+  /const services = await plugin\.ensureServicesInitialized\(\);[\s\S]*await services\.highlightManager\.handleFileRename\(oldPath, file\.path\)/,
+  "rename handler should initialize HiNote services before migrating highlights",
+);
+
+assert.doesNotMatch(
+  bootstrap,
+  /const services = plugin\.services;[\s\S]*if \(services\)/,
+  "rename handler should not skip migration when services are still lazy",
+);
+
+assert.match(
+  dataManager,
+  /const newSafeFileName = FilePathUtils\.toSafeFileName\(newPath\);[\s\S]*const newStoragePath = `\$\{FilePathUtils\.getHighlightsDir\(this\.vaultPath\)\}\/\$\{newSafeFileName\}`;/,
+  "highlight migration should compute the target storage path without creating a stale mapping first",
+);
+
+assert.match(
+  dataManager,
+  /this\.fileMappingStore\.set\(newPath, newSafeFileName\);/,
+  "highlight migration should persist the new path mapping after the file data is written",
+);
+
+assert.doesNotMatch(
+  dataManager,
+  /const newStoragePath = this\.getStoragePathForFile\(newPath\);/,
+  "highlight migration should not call getStoragePathForFile(newPath) before the old data is read",
+);

--- a/src/plugin/PluginBootstrap.ts
+++ b/src/plugin/PluginBootstrap.ts
@@ -39,9 +39,11 @@ export function registerPluginCommands(plugin: CommentPlugin, windowManager: Win
 export function registerPluginVaultEvents(plugin: CommentPlugin): void {
     plugin.registerEvent(
         plugin.app.vault.on('rename', async (file, oldPath) => {
-            const services = plugin.services;
-            if (services) {
+            try {
+                const services = await plugin.ensureServicesInitialized();
                 await services.highlightManager.handleFileRename(oldPath, file.path);
+            } catch (error) {
+                console.error('[HiNote] Failed to migrate highlights after file rename:', error);
             }
         })
     );

--- a/src/storage/HiNoteDataManager.ts
+++ b/src/storage/HiNoteDataManager.ts
@@ -14,6 +14,7 @@ import {
     ensureHiNoteDirectoryStructure
 } from './HiNoteStorageLayout';
 import { FlashcardDataStore } from './FlashcardDataStore';
+import { FilePathUtils } from './FilePathUtils';
 
 /**
  * HiNote数据管理器 - 存储层（已重构）
@@ -152,7 +153,8 @@ export class HiNoteDataManager {
      */
     async handleFileRename(oldPath: string, newPath: string): Promise<void> {
         const oldStoragePath = this.getStoragePathForFile(oldPath);
-        const newStoragePath = this.getStoragePathForFile(newPath);
+        const newSafeFileName = FilePathUtils.toSafeFileName(newPath);
+        const newStoragePath = `${FilePathUtils.getHighlightsDir(this.vaultPath)}/${newSafeFileName}`;
 
         try {
             // 检查旧文件是否存在
@@ -162,13 +164,18 @@ export class HiNoteDataManager {
             await this.app.vault.adapter.write(newStoragePath, content);
             
             // 删除旧文件
-            await this.app.vault.adapter.remove(oldStoragePath);
+            if (oldStoragePath !== newStoragePath) {
+                await this.app.vault.adapter.remove(oldStoragePath);
+            }
             
             // 更新映射
             this.fileMappingStore.delete(oldPath);
+            this.fileMappingStore.set(newPath, newSafeFileName);
             await this.saveFileMapping();
         } catch {
-            // 旧文件可能不存在，忽略错误
+            // 旧文件可能不存在，确保旧路径不会继续指向不存在的数据
+            this.fileMappingStore.delete(oldPath);
+            await this.saveFileMapping();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes HiNote highlight/comment data migration when an Obsidian note is renamed or moved.

Fixes #87.

## Root Cause

The vault `rename` event handler skipped migration unless HiNote services had already been initialized. This means renaming or moving a file before opening the HiNote panel could leave existing `.hinote` data attached to the old path. The migration code also computed the new storage path through `getStoragePathForFile(newPath)`, which could persist a new mapping before confirming that the old highlight data was actually readable.

## Changes

- Initialize HiNote services from the vault rename handler before migrating highlight data.
- Compute the new safe highlight storage path without pre-creating a mapping.
- Persist the new mapping only after the old highlight data has been read and written to the new storage path.
- Add a small regression script that checks the rename handler and migration logic.

## Validation

- `node scripts/test-hinote-rename-fix.mjs`
- `npm run build`
