### PR TITLE
fix(comment): do not save on the Enter that commits an IME conversion

### DIFF
--- a/src/components/comment/CommentInputKeyboard.ts
+++ b/src/components/comment/CommentInputKeyboard.ts
@@ -5,10 +5,24 @@ export interface CommentInputKeyboardOptions {
     onSave: () => Promise<void>;
 }
 
+/** Ignore an Enter arriving this soon after compositionend (IME commit echo). */
+const COMPOSITION_GUARD_MS = 100;
+
 export function setupCommentInputKeyboard(
     textarea: HTMLTextAreaElement,
     options: CommentInputKeyboardOptions
 ): void {
+    let composing = false;
+    let compositionEndedAt = 0;
+
+    textarea.addEventListener('compositionstart', () => {
+        composing = true;
+    });
+    textarea.addEventListener('compositionend', () => {
+        composing = false;
+        compositionEndedAt = Date.now();
+    });
+
     textarea.onkeydown = async (event: KeyboardEvent) => {
         if (event.key === 'Tab') {
             event.preventDefault();
@@ -17,6 +31,21 @@ export function setupCommentInputKeyboard(
         }
 
         if (event.key !== 'Enter') {
+            return;
+        }
+
+        // Do not treat the Enter that confirms an IME conversion as "save".
+        // With CJK input (Japanese/Chinese/Korean), Enter is used to commit the
+        // candidate, so without this guard the comment is saved and the textarea
+        // closes in the middle of typing a word.
+        // keyCode 229 is the conventional value browsers report while an IME is
+        // handling the key, and some environments dispatch keydown right after
+        // compositionend with isComposing already false - hence the extra flag.
+        if (composing || event.isComposing || event.keyCode === 229) {
+            return;
+        }
+
+        if (Date.now() - compositionEndedAt < COMPOSITION_GUARD_MS) {
             return;
         }
 


### PR DESCRIPTION
Fixes #91.

## Problem

The comment textarea treats every `Enter` as "save". With a CJK IME, `Enter` is also the key that commits the current conversion candidate, so the first `Enter` pressed while converting saves a half-written comment and closes the input. Writing a comment in Japanese is effectively impossible without avoiding conversion.

## Fix

Guard the save path with the composition state in `CommentInputKeyboard.ts`:

- track `compositionstart` / `compositionend` on the textarea
- bail out when `event.isComposing` or `event.keyCode === 229` (the conventional value reported while an IME handles the key)
- also ignore an `Enter` arriving within 100ms of `compositionend`, because some environments dispatch `keydown` right after `compositionend` with `isComposing` already `false`

The three checks are deliberately redundant: `isComposing` alone is not reliable across IMEs and platforms for the commit keystroke.

No behaviour change for non-IME input: `Enter` still saves, `Shift + Enter` still inserts a newline, mobile is untouched.

## Testing

Manually on macOS with the Japanese (romaji) input source, Obsidian 1.8:

- type `nihongo`, press `Enter` → conversion is committed, the input stays open (previously: saved and closed)
- press `Enter` again on the committed text → saves, as before
- `Shift + Enter` → newline, as before
- ASCII-only input with the IME off → `Enter` saves, unchanged

## Notes

The diff is one file, +29 lines, no dependency or API changes.
